### PR TITLE
Add Share Your Steps plugin and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # Shareyoursteps-explorer
-plugin per il sito con mappa migliorata
+
+Plugin WordPress per visualizzare una mappa interattiva dei percorsi condivisi tramite Leaflet.
+
+## Installazione
+
+1. Copia la cartella `wp-content/plugins/share-your-steps` all'interno della tua installazione di WordPress.
+2. Dalla bacheca di WordPress attiva **Share Your Steps** oppure sposta la cartella in `wp-content/mu-plugins` per averlo sempre attivo.
+3. Inserisci lo shortcode `[share_your_steps]` nella pagina o articolo in cui vuoi mostrare la mappa.
+
+## Dipendenze
+
+- [Leaflet](https://leafletjs.com/) viene caricato dal plugin tramite CDN.
+- Il sito deve essere servito tramite **HTTPS** per evitare problemi di contenuti misti quando vengono caricate risorse esterne.

--- a/wp-content/plugins/share-your-steps/share-your-steps.php
+++ b/wp-content/plugins/share-your-steps/share-your-steps.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Plugin Name: Share Your Steps
+ * Description: Display a Leaflet map to explore shared steps.
+ * Version: 1.0.0
+ * Author: Share Your Steps Team
+ * Requires at least: 6.0
+ * Requires PHP: 8.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+// Enqueue Leaflet assets from CDN.
+function sys_enqueue_leaflet_assets() {
+    wp_enqueue_style( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css', array(), '1.9.4' );
+    wp_enqueue_script( 'leaflet', 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js', array(), '1.9.4', true );
+}
+add_action( 'wp_enqueue_scripts', 'sys_enqueue_leaflet_assets' );
+
+// Shortcode to render map
+function sys_share_your_steps_shortcode( $atts = array() ) {
+    $atts = shortcode_atts( array(
+        'lat' => '0',
+        'lng' => '0',
+        'zoom' => '13',
+    ), $atts, 'share_your_steps' );
+
+    $map_id = 'sys-map-' . wp_rand();
+
+    ob_start();
+    ?>
+    <div id="<?php echo esc_attr( $map_id ); ?>" style="width:100%;height:400px;"></div>
+    <script>
+    document.addEventListener('DOMContentLoaded', function() {
+        var map = L.map('<?php echo esc_js( $map_id ); ?>').setView([<?php echo esc_js( $atts['lat'] ); ?>, <?php echo esc_js( $atts['lng'] ); ?>], <?php echo esc_js( $atts['zoom'] ); ?>);
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            maxZoom: 19,
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        }).addTo(map);
+    });
+    </script>
+    <?php
+    return ob_get_clean();
+}
+add_shortcode( 'share_your_steps', 'sys_share_your_steps_shortcode' );


### PR DESCRIPTION
## Summary
- add Share Your Steps WordPress plugin with Leaflet-based map shortcode
- document installation steps and HTTPS/Leaflet dependencies

## Testing
- `php -l wp-content/plugins/share-your-steps/share-your-steps.php`
- `php wp-cli.phar core download --path=wordpress --allow-root` *(fails: CONNECT tunnel failed, response 403)*
- `php wp-cli.phar plugin list --path=wordpress --allow-root` *(fails: This does not seem to be a WordPress installation)*

------
https://chatgpt.com/codex/tasks/task_e_68b81ed0af48832a8e0540a9f2a21bec