### PR TITLE
Add text domain and internationalization

### DIFF
--- a/wp-content/plugins/share-your-steps/languages/share-your-steps.pot
+++ b/wp-content/plugins/share-your-steps/languages/share-your-steps.pot
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Share Your Steps package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: Share Your Steps 1.0.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-03 15:03+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: wp-content/plugins/share-your-steps/share-your-steps.php:14
+msgid "No direct script access allowed."
+msgstr ""
+
+#: wp-content/plugins/share-your-steps/share-your-steps.php:49
+msgid "Loading map..."
+msgstr ""

--- a/wp-content/plugins/share-your-steps/share-your-steps.php
+++ b/wp-content/plugins/share-your-steps/share-your-steps.php
@@ -6,11 +6,19 @@
  * Author: Share Your Steps Team
  * Requires at least: 6.0
  * Requires PHP: 8.0
+ * Text Domain: share-your-steps
+ * Domain Path: /languages
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly
+    wp_die( esc_html( __( 'No direct script access allowed.', 'share-your-steps' ) ) );
 }
+
+// Load plugin text domain.
+function sys_load_textdomain() {
+    load_plugin_textdomain( 'share-your-steps', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'init', 'sys_load_textdomain' );
 
 // Enqueue Leaflet assets from CDN.
 function sys_enqueue_leaflet_assets() {
@@ -38,6 +46,6 @@ function sys_share_your_steps_shortcode( $atts = array() ) {
 
     $map_id = 'sys-map-' . wp_rand();
 
-    return '<div id="' . esc_attr( $map_id ) . '" class="sys-map" data-lat="' . esc_attr( $atts['lat'] ) . '" data-lng="' . esc_attr( $atts['lng'] ) . '" data-zoom="' . esc_attr( $atts['zoom'] ) . '"></div>';
+    return '<div id="' . esc_attr( $map_id ) . '" class="sys-map" data-lat="' . esc_attr( $atts['lat'] ) . '" data-lng="' . esc_attr( $atts['lng'] ) . '" data-zoom="' . esc_attr( $atts['zoom'] ) . '">' . esc_html( __( 'Loading map...', 'share-your-steps' ) ) . '</div>';
 }
 add_shortcode( 'share_your_steps', 'sys_share_your_steps_shortcode' );


### PR DESCRIPTION
## Summary
- Add Text Domain header and load text domain
- Translate user-facing strings and add placeholder text
- Generate initial POT file for translations

## Testing
- `php -l wp-content/plugins/share-your-steps/share-your-steps.php`
- `xgettext --package-name="Share Your Steps" --package-version="1.0.0" --language=PHP --from-code=UTF-8 --keyword=__ --keyword=_e -o wp-content/plugins/share-your-steps/languages/share-your-steps.pot wp-content/plugins/share-your-steps/share-your-steps.php`


------
https://chatgpt.com/codex/tasks/task_e_68b8585b3350832abdf45626a2dfddd3