### PR TITLE
Add secure AJAX handler and HTTPS enforcement

### DIFF
--- a/wp-content/plugins/share-your-steps/assets/js/chat.min.js
+++ b/wp-content/plugins/share-your-steps/assets/js/chat.min.js
@@ -1,1 +1,1 @@
-export default class Chat{init(){console.log('Chat initialized');}}
+export default class Chat{init(){console.log('Chat initialized');if(!window?.shareYourSteps?.ajax_url)return;const data=new URLSearchParams({action:'sys_handle_message',message:'Hello'});fetch(window.shareYourSteps.ajax_url,{method:'POST',headers:{'Content-Type':'application/x-www-form-urlencoded; charset=UTF-8'},body:data}).then(r=>r.json()).then(res=>console.log(res)).catch(err=>console.error(err));}}


### PR DESCRIPTION
## Summary
- Enqueue localized data for AJAX URL and add Chat module fetch example
- Add HTTPS redirect for non-secure requests
- Add AJAX callback with `current_user_can` and anti-spam checks

## Testing
- `php -l wp-content/plugins/share-your-steps/share-your-steps.php`
- `node --check wp-content/plugins/share-your-steps/assets/js/chat.min.js`


------
https://chatgpt.com/codex/tasks/task_e_68b85c45b9b8832abd3fcd496407a5c5