### PR TITLE
Allow configuring HTTPS redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,11 @@ Plugin WordPress per visualizzare una mappa interattiva dei percorsi condivisi t
 
 - [Leaflet](https://leafletjs.com/) viene caricato dal plugin tramite CDN.
 - Il sito deve essere servito tramite **HTTPS** per evitare problemi di contenuti misti quando vengono caricate risorse esterne.
+
+## Opzioni
+
+- Il reindirizzamento automatico verso HTTPS può essere disabilitato aggiungendo il seguente filtro in un plugin o nel tema attivo:
+
+```php
+add_filter( 'sys_force_https_enabled', '__return_false' );
+```

--- a/wp-content/plugins/share-your-steps/share-your-steps.php
+++ b/wp-content/plugins/share-your-steps/share-your-steps.php
@@ -61,6 +61,21 @@ add_shortcode( 'share_your_steps', 'sys_share_your_steps_shortcode' );
 
 // Force HTTPS for all front-end requests.
 function sys_force_https() {
+    if ( is_admin() || ! wp_is_https_supported() ) {
+        return;
+    }
+
+    /**
+     * Filter whether Share Your Steps should force a redirect to HTTPS.
+     *
+     * @since 1.0.0
+     *
+     * @param bool $enabled Whether the redirect is enabled. Default true.
+     */
+    if ( false === apply_filters( 'sys_force_https_enabled', true ) ) {
+        return;
+    }
+
     if ( ! is_ssl() ) {
         $location = 'https://' . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
         wp_safe_redirect( $location, 301 );


### PR DESCRIPTION
## Summary
- Check HTTPS support and skip forcing HTTPS in admin
- Add `sys_force_https_enabled` filter to disable redirect
- Document redirect filter in README

## Testing
- `composer test`
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b94add49b8832abc853874671ebf94