### PR TITLE
Use transients for rate limiting

### DIFF
--- a/wp-content/plugins/share-your-steps/tests/UtilsTest.php
+++ b/wp-content/plugins/share-your-steps/tests/UtilsTest.php
@@ -8,12 +8,25 @@ class UtilsTest extends TestCase {
     }
 
     public function test_rate_limiter() {
-        $key = 'test';
-        $limit = 2;
-        $interval = 60;
-        $this->assertTrue(sys_rate_limiter($key, $limit, $interval));
-        $this->assertTrue(sys_rate_limiter($key, $limit, $interval));
-        $this->assertFalse(sys_rate_limiter($key, $limit, $interval));
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $key       = 'test';
+        $limit     = 2;
+        $interval  = 1; // Use short interval for tests.
+        $transient = 'sys_rate_' . $key . '_ip_' . $_SERVER['REMOTE_ADDR'];
+
+        $this->assertTrue( sys_rate_limiter( $key, $limit, $interval ) );
+        $this->assertTrue( sys_rate_limiter( $key, $limit, $interval ) );
+        $this->assertFalse( sys_rate_limiter( $key, $limit, $interval ) );
+
+        // Transient should exist after hitting the limit.
+        $this->assertIsArray( get_transient( $transient ) );
+
+        // Wait for interval to expire and ensure transient is cleared.
+        sleep( $interval + 1 );
+        $this->assertFalse( get_transient( $transient ) );
+
+        // New window should allow requests again.
+        $this->assertTrue( sys_rate_limiter( $key, $limit, $interval ) );
     }
 
     public function test_chat_queue() {

--- a/wp-content/plugins/share-your-steps/tests/bootstrap.php
+++ b/wp-content/plugins/share-your-steps/tests/bootstrap.php
@@ -1,2 +1,40 @@
 <?php
-require dirname(__DIR__) . '/includes/utils.php';
+// Minimal stubs to simulate WordPress transient API for tests.
+
+global $sys_test_transients;
+$sys_test_transients = [];
+
+function set_transient( $key, $value, $expiration ) {
+    global $sys_test_transients;
+    $sys_test_transients[ $key ] = [
+        'value'      => $value,
+        'expiration' => time() + (int) $expiration,
+    ];
+    return true;
+}
+
+function get_transient( $key ) {
+    global $sys_test_transients;
+    if ( ! isset( $sys_test_transients[ $key ] ) ) {
+        return false;
+    }
+    if ( $sys_test_transients[ $key ]['expiration'] < time() ) {
+        unset( $sys_test_transients[ $key ] );
+        return false;
+    }
+    return $sys_test_transients[ $key ]['value'];
+}
+
+function delete_transient( $key ) {
+    global $sys_test_transients;
+    unset( $sys_test_transients[ $key ] );
+    return true;
+}
+
+// Provide stub for current user ID.
+function get_current_user_id() {
+    return 0;
+}
+
+require dirname( __DIR__ ) . '/includes/utils.php';
+


### PR DESCRIPTION
## Summary
- Refactor `sys_rate_limiter` to leverage WordPress transients keyed by user ID or IP and purge expired entries
- Add test stubs for the WordPress transient API
- Expand rate limiter tests to cover transient expiry and reuse

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b94ba2e100832abdb37de10035adf6