### PR TITLE
Add configurable WebSocket endpoint for Share Your Steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ I file `*.min.js` verranno generati nella cartella `wp-content/plugins/share-you
 
 ## Opzioni
 
+- Dalla pagina **Settings → Share Your Steps** è possibile configurare l'endpoint WebSocket. Il valore predefinito è `ws://localhost:8080`.
 - Il reindirizzamento automatico verso HTTPS può essere disabilitato aggiungendo il seguente filtro in un plugin o nel tema attivo:
 
 ```php


### PR DESCRIPTION
## Summary
- add `sys_websocket_url` option with default `ws://localhost:8080`
- expose an admin settings page to customize the WebSocket endpoint
- localize frontend script using saved option value
- document WebSocket configuration in README

## Testing
- `composer test`
- `npm run build`
- `npm run test:e2e` *(fails: libasound.so.2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b960556694832a9bb24cb3224d4492