### PR TITLE
Paginate live route cleanup for sys_route posts

### DIFF
--- a/wp-content/plugins/share-your-steps/share-your-steps.php
+++ b/wp-content/plugins/share-your-steps/share-your-steps.php
@@ -371,27 +371,34 @@ add_action( 'sys_cleanup_live_routes', 'sys_cleanup_old_live_routes' );
 
 // Remove live routes older than a week.
 function sys_cleanup_old_live_routes() {
-    $args  = array(
-        'post_type'      => 'any',
-        'post_status'    => 'any',
-        'posts_per_page' => -1,
-        'fields'         => 'ids',
-        'meta_query'     => array(
-            array(
-                'key'     => '_sys_live_coords_updated',
-                'value'   => time() - WEEK_IN_SECONDS,
-                'compare' => '<',
-                'type'    => 'NUMERIC',
+    $paged = 1;
+
+    do {
+        $args  = array(
+            'post_type'      => 'sys_route',
+            'post_status'    => 'any',
+            'posts_per_page' => 100,
+            'paged'          => $paged,
+            'fields'         => 'ids',
+            'meta_query'     => array(
+                array(
+                    'key'     => '_sys_live_coords_updated',
+                    'value'   => time() - WEEK_IN_SECONDS,
+                    'compare' => '<',
+                    'type'    => 'NUMERIC',
+                ),
             ),
-        ),
-    );
+        );
 
-    $query = new WP_Query( $args );
+        $query = new WP_Query( $args );
 
-    foreach ( $query->posts as $post_id ) {
-        delete_post_meta( $post_id, '_sys_live_coords' );
-        delete_post_meta( $post_id, '_sys_live_coords_updated' );
-    }
+        foreach ( $query->posts as $post_id ) {
+            delete_post_meta( $post_id, '_sys_live_coords' );
+            delete_post_meta( $post_id, '_sys_live_coords_updated' );
+        }
+
+        $paged++;
+    } while ( ! empty( $query->posts ) );
 }
 
 // Handle chat messages with basic anti-spam checks.


### PR DESCRIPTION
## Summary
- Limit cleanup query to `sys_route` posts and process in pages of 100 to avoid memory spikes
- Extend test bootstrap with meta deletion and WP_Query filtering support
- Add unit test ensuring only `sys_route` posts are purged

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68b96471b750832a88c4f17d311f1cba