### PR TITLE
Handle proxy IPs in rate limiter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,10 @@ I file `*.min.js` verranno generati nella cartella `wp-content/plugins/share-you
 ```php
 add_filter( 'sys_force_https_enabled', '__return_false' );
 ```
+
+## Proxy
+
+Quando il sito è dietro un proxy o un bilanciatore di carico, il plugin utilizza le intestazioni
+`HTTP_X_FORWARDED_FOR` e `HTTP_CLIENT_IP` per determinare l'indirizzo IP del client ai fini del
+rate limiting. Assicurarsi che il proxy inoltri correttamente tali intestazioni.
+

--- a/wp-content/plugins/share-your-steps/tests/UtilsTest.php
+++ b/wp-content/plugins/share-your-steps/tests/UtilsTest.php
@@ -9,6 +9,7 @@ class UtilsTest extends TestCase {
 
     public function test_rate_limiter() {
         $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        unset( $_SERVER['HTTP_CLIENT_IP'], $_SERVER['HTTP_X_FORWARDED_FOR'] );
         $key       = 'test';
         $limit     = 2;
         $interval  = 1; // Use short interval for tests.
@@ -27,6 +28,40 @@ class UtilsTest extends TestCase {
 
         // New window should allow requests again.
         $this->assertTrue( sys_rate_limiter( $key, $limit, $interval ) );
+    }
+
+    public function test_rate_limiter_forwarded_ip() {
+        $_SERVER['REMOTE_ADDR']       = '127.0.0.1';
+        $_SERVER['HTTP_X_FORWARDED_FOR'] = '8.8.8.8, 1.1.1.1';
+        unset( $_SERVER['HTTP_CLIENT_IP'] );
+
+        $key       = 'fwd';
+        $limit     = 1;
+        $interval  = 1;
+        $transient = 'sys_rate_' . $key . '_ip_8.8.8.8';
+
+        $this->assertTrue( sys_rate_limiter( $key, $limit, $interval ) );
+        $this->assertIsArray( get_transient( $transient ) );
+
+        delete_transient( $transient );
+        unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+    }
+
+    public function test_rate_limiter_client_ip() {
+        $_SERVER['REMOTE_ADDR']     = '127.0.0.1';
+        $_SERVER['HTTP_CLIENT_IP']  = '9.9.9.9';
+        unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+
+        $key       = 'client';
+        $limit     = 1;
+        $interval  = 1;
+        $transient = 'sys_rate_' . $key . '_ip_9.9.9.9';
+
+        $this->assertTrue( sys_rate_limiter( $key, $limit, $interval ) );
+        $this->assertIsArray( get_transient( $transient ) );
+
+        delete_transient( $transient );
+        unset( $_SERVER['HTTP_CLIENT_IP'] );
     }
 
     public function test_chat_queue() {


### PR DESCRIPTION
## Summary
- Extract client IP considering `HTTP_X_FORWARDED_FOR` and `HTTP_CLIENT_IP` headers with validation
- Document proxy header usage for rate limiting
- Cover proxy header scenarios with new unit tests

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68b966a987a0832aaf010556b275bd46