### PR TITLE
Add Cypress test for Share Your Steps shortcode

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,7 +2,7 @@ const { defineConfig } = require('cypress');
 
 module.exports = defineConfig({
   e2e: {
-    baseUrl: 'https://example.com',
+    baseUrl: process.env.WP_BASE_URL || 'http://localhost:8888',
     supportFile: false,
   },
 });

--- a/cypress/e2e/home.cy.js
+++ b/cypress/e2e/home.cy.js
@@ -1,6 +1,0 @@
-describe('Example front-end', () => {
-  it('loads the example domain', () => {
-    cy.visit('/');
-    cy.contains('Example Domain');
-  });
-});

--- a/cypress/e2e/share_your_steps.cy.js
+++ b/cypress/e2e/share_your_steps.cy.js
@@ -1,0 +1,13 @@
+describe('Share Your Steps shortcode', () => {
+  it('renders the map and initializes Tracking and Chat', () => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        cy.spy(win.console, 'log').as('consoleLog');
+      },
+    });
+
+    cy.get('.sys-map').should('exist');
+    cy.get('@consoleLog').should('be.calledWith', 'Tracking initialized');
+    cy.get('@consoleLog').should('be.calledWith', 'Chat initialized');
+  });
+});


### PR DESCRIPTION
## Summary
- run e2e test visiting page with `[share_your_steps]` and assert map plus Tracking & Chat logs
- configure Cypress to hit local WordPress instance via environment-based baseUrl
- remove legacy placeholder test

## Testing
- `npm run test:e2e` *(fails: missing Xvfb dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68b9675e850c832aaa128203368bc2db