### PR TITLE
Load map script as module

### DIFF
--- a/wp-content/plugins/share-your-steps/share-your-steps.php
+++ b/wp-content/plugins/share-your-steps/share-your-steps.php
@@ -44,8 +44,9 @@ function sys_enqueue_assets() {
         plugins_url( 'assets/js/map.min.js', __FILE__ ),
         array( 'leaflet' ),
         '1.0.0',
-        array( 'in_footer' => true, 'type' => 'module' )
+        true
     );
+    wp_script_add_data( 'share-your-steps', 'type', 'module' );
     wp_enqueue_script( 'share-your-steps' );
     wp_localize_script(
         'share-your-steps',


### PR DESCRIPTION
## Summary
- register map script in footer
- mark map script as a JS module

## Testing
- `phpunit -c phpunit.xml.dist`
- `npm run test:e2e` *(fails: missing dependency Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b98bf3178c832a8f82cfc5fbcb1a72