### PR TITLE
Add option to force HTTPS redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ I file `*.min.js` verranno generati nella cartella `wp-content/plugins/share-you
 ## Opzioni
 
 - Dalla pagina **Settings → Share Your Steps** è possibile configurare l'endpoint WebSocket. Il valore predefinito è `ws://localhost:8080`.
-- Il reindirizzamento automatico verso HTTPS può essere disabilitato aggiungendo il seguente filtro in un plugin o nel tema attivo:
+- Dalla stessa pagina è possibile attivare l'opzione **Force HTTPS** che reindirizza automaticamente le visite verso la versione sicura del sito. Attivala solo se il sito è raggiungibile tramite HTTPS ma WordPress è configurato con schema HTTP.
+- Il reindirizzamento può essere disabilitato in modo programmatico aggiungendo il seguente filtro in un plugin o nel tema attivo:
 
 ```php
 add_filter( 'sys_force_https_enabled', '__return_false' );

--- a/wp-content/plugins/share-your-steps/languages/share-your-steps.pot
+++ b/wp-content/plugins/share-your-steps/languages/share-your-steps.pot
@@ -24,3 +24,7 @@ msgstr ""
 #: wp-content/plugins/share-your-steps/share-your-steps.php:49
 msgid "Loading map..."
 msgstr ""
+
+#: wp-content/plugins/share-your-steps/share-your-steps.php:148
+msgid "Force HTTPS"
+msgstr ""


### PR DESCRIPTION
## Summary
- add `sys_force_https` setting to Share Your Steps options page
- check `sys_force_https` and `home_url()` scheme before redirecting
- document when to enable HTTPS redirection and allow overriding via filter

## Testing
- `composer test`
- `npm run test:e2e` *(fails: Your system is missing the dependency: Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68b98eb73db8832a9ccfe1bbc519179f